### PR TITLE
#2 feat: 버튼 컴포넌트 추가

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,5 +7,8 @@
   ],
   "parserOptions": {
     "project": "./tsconfig.json"
+  },
+  "rules": {
+    "object-curly-newline": "off"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,12 @@
       "dependencies": {
         "@ant-design/nextjs-registry": "^1.0.0",
         "antd-mobile": "^5.34.0",
+        "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
         "next": "14.1.0",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "tailwind-merge": "^2.2.1"
       },
       "devDependencies": {
         "@commitlint/cli": "^18.6.0",
@@ -9275,6 +9277,25 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
       "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
       "dev": true
+    },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.0.tgz",
+      "integrity": "sha512-jFI8IQw4hczaL4ALINxqLEXQbWcNjoSkloa4IaufXCJr6QawJyw7tuRysRsrE8w2p/4gGaxKIt/hX3qz/IbD1A==",
+      "dependencies": {
+        "clsx": "2.0.0"
+      },
+      "funding": {
+        "url": "https://joebell.co.uk"
+      }
+    },
+    "node_modules/class-variance-authority/node_modules/clsx": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
+      "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/classnames": {
       "version": "2.5.1",
@@ -19806,6 +19827,18 @@
       "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.17.tgz",
       "integrity": "sha512-AsS729u2RHUfEra9xJrE39peJcc2stq2+poBXX8bcM08Y6g9j/i/PUzwNQqkaJde7Ntg1TO7bSREbR5sdosQ+g==",
       "dev": true
+    },
+    "node_modules/tailwind-merge": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.2.1.tgz",
+      "integrity": "sha512-o+2GTLkthfa5YUt4JxPfzMIpQzZ3adD1vLVkvKE1Twl9UAhGsEbIZhHHZVRttyW177S8PDJI3bTQNaebyofK3Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.23.7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
     },
     "node_modules/tailwindcss": {
       "version": "3.4.1",

--- a/package.json
+++ b/package.json
@@ -16,10 +16,12 @@
   "dependencies": {
     "@ant-design/nextjs-registry": "^1.0.0",
     "antd-mobile": "^5.34.0",
+    "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "next": "14.1.0",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "tailwind-merge": "^2.2.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^18.6.0",

--- a/src/components/button/button.stories.tsx
+++ b/src/components/button/button.stories.tsx
@@ -5,16 +5,19 @@ const meta: Meta<typeof Button> = {
   title: '버튼',
   component: Button,
   argTypes: {
-    children: {
+    label: {
       control: 'text',
     },
     size: {
       control: 'radio',
       options: ['sm', 'md', 'lg', 'full'],
     },
-    accent: {
-      control: 'boolean',
-      options: ['true', 'false'],
+    variant: {
+      control: 'radio',
+      options: ['default', 'primary', 'selected', 'disabled'],
+    },
+    className: {
+      control: 'text',
     },
   },
 };
@@ -24,8 +27,8 @@ type Story = StoryObj<typeof Button>;
 
 export const ButtonStory: Story = {
   args: {
-    children: 'Button',
+    label: 'Button',
     size: 'sm',
-    accent: false,
+    variant: 'default',
   },
 };

--- a/src/components/button/button.stories.tsx
+++ b/src/components/button/button.stories.tsx
@@ -1,0 +1,31 @@
+import Button from '@/components/button/button';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof Button> = {
+  title: '버튼',
+  component: Button,
+  argTypes: {
+    children: {
+      control: 'text',
+    },
+    size: {
+      control: 'radio',
+      options: ['sm', 'md', 'lg', 'full'],
+    },
+    accent: {
+      control: 'boolean',
+      options: ['true', 'false'],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Button>;
+
+export const ButtonStory: Story = {
+  args: {
+    children: 'Button',
+    size: 'sm',
+    accent: false,
+  },
+};

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import clsx from 'clsx';
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  children: React.ReactNode;
+  size: 'sm' | 'md' | 'lg' | 'full';
+  accent: boolean;
+}
+export default function Button({
+  children,
+  onClick,
+  size,
+  accent = false,
+}: ButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={clsx(
+        'transition-opacity duration-200 active:opacity-80',
+        {
+          'f12 rounded bg-button_default_bg px-2 py-1.5 font-semibold':
+            size === 'sm',
+          'f14 rounded bg-button_default_bg px-3 py-1.5 font-semibold':
+            size === 'md',
+          'f14 rounded bg-button_default_bg px-4 py-1.5 font-semibold':
+            size === 'lg',
+          'f16 h-12 w-full rounded-md bg-theme_primary font-bold':
+            size === 'full',
+        },
+        {
+          'text-white': size === 'full',
+          'text-text_primary': !accent,
+          'text-theme_secondary': accent && size !== 'full',
+        },
+      )}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -1,41 +1,57 @@
-import React from 'react';
-import clsx from 'clsx';
+'use client';
 
-interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  children: React.ReactNode;
+import React from 'react';
+import { cva } from 'class-variance-authority';
+import cn from '@/utils/cn';
+
+interface ButtonProps {
+  label: string;
+  variant: 'default' | 'primary' | 'selected' | 'disabled';
   size: 'sm' | 'md' | 'lg' | 'full';
-  accent: boolean;
+  className: string;
+  onClick: () => void;
 }
+
+const ButtonVariants = cva(
+  'transition-opacity duration-200 active:opacity-80',
+  {
+    variants: {
+      variant: {
+        default: 'bg-button_default_bg text-text_primary',
+        primary: 'bg-theme_primary text-white',
+        selected: 'bg-button_default_bg text-theme_secondary',
+        disabled: ' bg-button_default_bg text-theme_tertiary',
+      },
+      size: {
+        sm: 'f12 rounded px-2 py-1.5 font-semibold',
+        md: 'f14 rounded px-3 py-1.5 font-semibold',
+        lg: 'f14 rounded px-4 py-1.5 font-semibold',
+        full: 'f16 h-12 w-full rounded-md font-bold',
+      },
+    },
+  },
+);
+
 export default function Button({
-  children,
-  onClick,
+  label,
+  variant,
   size,
-  accent = false,
+  className = '',
+  onClick,
 }: ButtonProps) {
   return (
     <button
       type="button"
       onClick={onClick}
-      className={clsx(
-        'transition-opacity duration-200 active:opacity-80',
-        {
-          'f12 rounded bg-button_default_bg px-2 py-1.5 font-semibold':
-            size === 'sm',
-          'f14 rounded bg-button_default_bg px-3 py-1.5 font-semibold':
-            size === 'md',
-          'f14 rounded bg-button_default_bg px-4 py-1.5 font-semibold':
-            size === 'lg',
-          'f16 h-12 w-full rounded-md bg-theme_primary font-bold':
-            size === 'full',
-        },
-        {
-          'text-white': size === 'full',
-          'text-text_primary': !accent,
-          'text-theme_secondary': accent && size !== 'full',
-        },
+      className={cn(
+        ButtonVariants({
+          size,
+          variant,
+        }),
+        className,
       )}
     >
-      {children}
+      {label}
     </button>
   );
 }

--- a/src/utils/cn.ts
+++ b/src/utils/cn.ts
@@ -1,0 +1,6 @@
+import { ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export default function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
This PR Resolves #2 
## 버튼 컴포넌트
- 모바일 앱에서 동작하기 때문에 호버를 고려 X
- active는 투명도 조절로 함 -> 디자인 할거면 다시 적용할게요

<img width="691" alt="image" src="https://github.com/se-gam/segam-web/assets/45655623/3768d79d-cf34-4699-ba01-79cb46dedccd">

- 이런 느낌으로 생각하고 만들었습니다.

![image](https://github.com/se-gam/segam-web/assets/45655623/1d1ae83a-45dc-4d00-a4db-fc75b98ccf99)
- 해당 컴포넌트는 버튼이라고 하기엔 라디오 버튼에 가까운 느낌이라 버튼 컴포넌트랑 분리하는게 나을 것 같다고 생각함