### PR TITLE
[#3] feat: 태그 컴포넌트 추가

### DIFF
--- a/src/components/tag/tag.stories.ts
+++ b/src/components/tag/tag.stories.ts
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Tag from '@/components/tag/tag';
+
+const meta: Meta<typeof Tag> = {
+  component: Tag,
+  argTypes: {
+    children: {
+      control: 'text',
+    },
+    size: {
+      control: 'radio',
+      options: ['sm', 'md'],
+    },
+    className: {
+      control: 'radio',
+      options: [
+        'bg-button_default_bg text-text_primary',
+        'bg-tag_blue_bg text-tag_blue_text',
+        'bg-tag_orange_bg text-tag_orange_text',
+        'bg-tag_yellow_bg text-tag_red_text',
+        'bg-tag_yellow_bg text-tag_yellow_text',
+        'bg-button_default_bg text-error',
+      ],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Tag>;
+
+export const TagStory: Story = {
+  args: {
+    children: 'Tag',
+    size: 'sm',
+    className: 'bg-button_default_bg text-text_primary',
+  },
+};

--- a/src/components/tag/tag.tsx
+++ b/src/components/tag/tag.tsx
@@ -1,0 +1,28 @@
+import clsx from 'clsx';
+import React from 'react';
+
+interface TagProps extends React.HTMLAttributes<HTMLSpanElement> {
+  children: React.ReactNode;
+  size: 'sm' | 'md';
+}
+
+export default function Tag({
+  children,
+  size,
+  className = 'bg-button_default_bg text-text_primary',
+}: TagProps) {
+  return (
+    <span
+      className={clsx(
+        'rounded font-semibold',
+        {
+          'f12 px-2 py-1': size === 'sm',
+          'f14 px-3 py-1': size === 'md',
+        },
+        className,
+      )}
+    >
+      {children}
+    </span>
+  );
+}


### PR DESCRIPTION
This PR Resolves #3 
## 태그 컴포넌트 제작
- sm, md사이즈를 나누어 태그를 제작
- color는 분포가 너무 다양해서 variant로 미리 정의해두는 것 보다 사용할 때 마다 `className`을 `props`로 넘겨준다.
- 기본 값은 흰배경에 회색 글씨


**고려해볼 사항** 
- 타입 지정
<img width="324" alt="image" src="https://github.com/se-gam/segam-web/assets/45655623/0a6d7764-d1be-4590-a745-ac8288cdea33">
