### PR TITLE
[#70] feat: 스터디룸 예약 취소 모달 추가

### DIFF
--- a/src/app/(root)/dashboard/(overview)/page.tsx
+++ b/src/app/(root)/dashboard/(overview)/page.tsx
@@ -60,7 +60,7 @@ export default async function DashBoard() {
             return null;
           })}
         </Board>
-        <Board title="나의 예약현황" url="dashboard/studyroom">
+        <Board title="내 예약현황" url="dashboard/studyroom">
           {reservationData.length === 0 && (
             <div className="flex h-20 w-full items-center justify-center rounded-lg">
               <p className="f16 font-medium text-text_secondary">예약내역이 존재하지 않습니다.</p>
@@ -72,6 +72,7 @@ export default async function DashBoard() {
               title={item.title}
               description={item.description}
               iconName={item.iconName}
+              id={item.id}
             />
           ))}
         </Board>

--- a/src/components/dashboard/card/studyRoomCard.tsx
+++ b/src/components/dashboard/card/studyRoomCard.tsx
@@ -1,12 +1,18 @@
+'use client';
+
 import Button from '@/components/common/button/button';
 import Icons from '@/components/common/icons/icons';
+import useModal from '@/hooks/useModal';
+import { cancelReservation } from '@/lib/actions/studyroom';
 
 interface StudyRoomCardProps {
+  id: number;
   title: string;
   description: string;
   iconName: string;
 }
-export default function StudyRoomCard({ title, iconName, description }: StudyRoomCardProps) {
+export default function StudyRoomCard({ id, title, iconName, description }: StudyRoomCardProps) {
+  const { confirmModal } = useModal();
   return (
     <div className="flex w-full items-center justify-between gap-4 rounded-md p-3">
       <div className="flex items-center gap-4">
@@ -18,7 +24,20 @@ export default function StudyRoomCard({ title, iconName, description }: StudyRoo
           <p className="f12 font-medium text-text_secondary">{description}</p>
         </div>
       </div>
-      <Button size="lg" variant="default" label="취소" />
+      <Button
+        size="lg"
+        variant="default"
+        label="취소"
+        onClick={() => {
+          confirmModal({
+            title: '예약 취소',
+            content: '예약을 취소하시겠습니까?',
+            onClick: () => {
+              cancelReservation(id);
+            },
+          });
+        }}
+      />
     </div>
   );
 }

--- a/src/components/studyroom/list/studyRoomReservationItem.tsx
+++ b/src/components/studyroom/list/studyRoomReservationItem.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import Button from '@/components/common/button/button';
 import Icons from '@/components/common/icons/icons';
+import useModal from '@/hooks/useModal';
 
 interface ReservationProps {
   id: number;
@@ -26,6 +27,7 @@ export default function StudyRoomReservationItem({
   users,
   onCancel,
 }: ReservationProps) {
+  const { confirmModal } = useModal();
   const [isExpanded, setIsExpanded] = useState(false);
   const formattedDate = new Date(date).toLocaleDateString('ko-KR', {
     month: 'long',
@@ -49,7 +51,13 @@ export default function StudyRoomReservationItem({
           variant="default"
           size="sm"
           type="button"
-          onClick={() => onCancel(id)}
+          onClick={() => {
+            confirmModal({
+              title: '예약 취소',
+              content: '예약을 취소하시겠습니까?',
+              onClick: () => onCancel(id),
+            });
+          }}
         />
       </div>
       <div className="flex">

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -1,3 +1,4 @@
+import Button from '@/components/common/button/button';
 import { Modal } from 'antd';
 
 interface ModalProps {
@@ -9,52 +10,53 @@ export default function useModal() {
   const modal = ({ title, content, onClick = () => null }: ModalProps) => {
     Modal.error({
       title: <h3 className="f20 font-bold text-text_primary">{title}</h3>,
-      content: <p className="f14 font-medium text-text_secondary">{content}</p>,
+      content: <p className="f16 font-medium text-text_secondary">{content}</p>,
+      footer: (
+        <Button
+          label="확인"
+          variant="primary"
+          size="full"
+          onClick={() => {
+            onClick();
+            Modal.destroyAll();
+          }}
+          className="mt-4"
+        />
+      ),
       icon: null,
       maskClosable: true,
-      okText: '확인',
-      okButtonProps: {
-        style: {
-          backgroundColor: '#626FE5',
-          color: 'white',
-          borderRadius: '4px',
-          border: 'none',
-        },
-      },
-      onOk: () => {
-        onClick();
-        Modal.destroyAll();
-      },
+      centered: true,
     });
   };
   const confirmModal = ({ title, content, onClick = () => null }: ModalProps) => {
     Modal.confirm({
       title: <h3 className="f20 font-bold text-text_primary">{title}</h3>,
-      content: <p className="f14 font-medium text-text_secondary">{content}</p>,
+      content: <p className="f16 font-medium text-text_secondary">{content}</p>,
+      footer: (
+        <div className="mt-4 flex flex-row">
+          <Button
+            label="취소"
+            variant="default"
+            size="full"
+            onClick={() => {
+              Modal.destroyAll();
+            }}
+            className="mr-2"
+          />
+          <Button
+            label="확인"
+            variant="primary"
+            size="full"
+            onClick={() => {
+              onClick();
+              Modal.destroyAll();
+            }}
+          />
+        </div>
+      ),
       icon: null,
       maskClosable: true,
-      okText: '확인',
-      cancelText: '취소',
-      okButtonProps: {
-        style: {
-          backgroundColor: '#626FE5',
-          color: 'white',
-          borderRadius: '4px',
-          border: 'none',
-        },
-      },
-      cancelButtonProps: {
-        style: {
-          backgroundColor: '#F5F6FA',
-          color: '#626FE5',
-          borderRadius: '4px',
-          border: 'none',
-        },
-      },
-      onOk: () => {
-        onClick();
-        Modal.destroyAll();
-      },
+      centered: true,
     });
   };
   return { modal, confirmModal };

--- a/src/lib/actions/studyroom.ts
+++ b/src/lib/actions/studyroom.ts
@@ -91,6 +91,7 @@ export async function cancelReservation(id: number) {
         cancelReason: '예약취소',
       },
     });
+    revalidateTag('reservationList');
   } catch (error) {
     throw new Error('예약 취소에 실패했습니다.');
   }
@@ -134,20 +135,25 @@ export async function reserveStudyroom({
   users,
 }: ReserveStudyroomProps) {
   const password = cookies().get('encrypted')?.value;
-  await fetchExtended(`/v1/studyroom/reservation`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${cookies().get('accessToken')?.value}`,
-    },
-    body: {
-      studyroomId,
-      password,
-      startsAt,
-      duration,
-      reason,
-      users,
-      date: date.toISOString(),
-    },
-  });
+  try {
+    await fetchExtended(`/v1/studyroom/reservation`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${cookies().get('accessToken')?.value}`,
+      },
+      body: {
+        studyroomId,
+        password,
+        startsAt,
+        duration,
+        reason,
+        users,
+        date: date.toISOString(),
+      },
+    });
+    revalidateTag('reservationList');
+  } catch (error) {
+    throw new Error('스터디룸 예약에 실패했습니다.');
+  }
 }


### PR DESCRIPTION
### 작업 내용
- useModal의 modal, confirmModal 디자인 수정 (footer 버튼 직접 추가)
- 대시보드 취소버튼 추가
- 대시보드 취소버튼 이벤트 confirmModal 통해 관리
- 스터디룸 취소버튼 이벤트 추가
- 스터디룸 취소버튼 이벤트 confirmModal 통해 관리
- cancelReservation시 캐시키 revalidate

### 특이사항
- 오래 걸리는 이벤트 로딩 처리 필요 -> 이후 suspense 이슈에 같이 작업