### PR TITLE
[#77, #78] feat: 스터디룸 빈 컴포넌트 추가, 디자인 수정

### DIFF
--- a/src/app/(root)/dashboard/studyroom/page.tsx
+++ b/src/app/(root)/dashboard/studyroom/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from 'react';
+import Loading from '@/components/common/loading';
 import StudyRoomView from './studyRoomView';
 import ReservationView from './reservationView';
 
@@ -20,9 +21,12 @@ export default async function Page({
       <header className="mb-4 pt-2.5">
         <h1 className="f20 font-bold text-text_primary">스터디룸</h1>
       </header>
-      <Suspense>
-        <ReservationView />
-      </Suspense>
+      <section className="mb-5 space-y-2">
+        <h1 className="f24 font-bold text-text_primary">내 예약 현황</h1>
+        <Suspense fallback={<Loading size="small" />}>
+          <ReservationView />
+        </Suspense>
+      </section>
       <StudyRoomView params={{ date, startsAt, endsAt }} />
     </main>
   );

--- a/src/app/(root)/dashboard/studyroom/reservationView.tsx
+++ b/src/app/(root)/dashboard/studyroom/reservationView.tsx
@@ -5,14 +5,15 @@ export default async function ReservationView() {
   const reservationListData = await getReservationList();
   return (
     <div>
-      {reservationListData && reservationListData.reservations.length > 0 && (
-        <section className="mb-5 space-y-2">
-          <h1 className="f24 font-bold text-text_primary">내 예약 현황</h1>
-          <StudyRoomReservationList
-            data={reservationListData.reservations}
-            onCancel={cancelReservation}
-          />
-        </section>
+      {reservationListData && reservationListData.reservations.length > 0 ? (
+        <StudyRoomReservationList
+          data={reservationListData.reservations}
+          onCancel={cancelReservation}
+        />
+      ) : (
+        <div className="flex h-10 items-center justify-center">
+          <p className="f16 font-medium text-text_secondary">예약 내역이 없습니다.</p>
+        </div>
       )}
     </div>
   );

--- a/src/app/(root)/dashboard/studyroom/studyRoomView.tsx
+++ b/src/app/(root)/dashboard/studyroom/studyRoomView.tsx
@@ -17,28 +17,34 @@ export default async function StudyRoomView({ params }: StudyRoomViewProps) {
 
   return (
     <div>
-      {studyroomListData && (
-        <section className="mb-5 space-y-2">
-          <div className="mb-4 flex h-8 items-center justify-between">
-            <div className="flex">
-              <h1 className="f24 mr-1 font-bold text-text_primary">예약하기</h1>
-              <p className="f14 flex self-end font-medium text-text_secondary">
-                {new Date(params.date).toLocaleDateString('ko-KR', {
-                  month: 'long',
-                  day: 'numeric',
-                })}
-              </p>
-            </div>
-            <StudyRoomModalButton />
+      <section className="mb-5 space-y-2">
+        <div className="mb-4 flex h-8 items-center justify-between">
+          <div className="flex">
+            <h1 className="f24 mr-1 font-bold text-text_primary">예약하기</h1>
+            <p className="f14 flex self-end font-medium text-text_secondary">
+              {new Date(params.date).toLocaleDateString('ko-KR', {
+                month: 'long',
+                day: 'numeric',
+              })}
+            </p>
           </div>
+          <StudyRoomModalButton />
+        </div>
+        {studyroomListData && studyroomListData.studyrooms.length > 0 ? (
           <StudyRoomSlotList
             data={studyroomListData?.studyrooms}
             date={params.date}
             startsAt={params.startsAt}
             endsAt={params.endsAt}
           />
-        </section>
-      )}
+        ) : (
+          <div className="flex items-center justify-center">
+            <p className="f16 mt-12 flex  font-medium text-text_secondary">
+              예약 가능한 스터디룸이 없습니다.
+            </p>
+          </div>
+        )}
+      </section>
     </div>
   );
 }

--- a/src/components/common/loading.tsx
+++ b/src/components/common/loading.tsx
@@ -1,0 +1,28 @@
+import { Spin } from 'antd';
+
+interface LoadingProps {
+  size?: 'small' | 'default' | 'large';
+  content?: string;
+}
+
+export default function Loading({ size = 'default', content }: LoadingProps) {
+  let spinSize;
+  switch (size) {
+    case 'small':
+      spinSize = 'small';
+      break;
+    case 'large':
+      spinSize = 'large';
+      break;
+    default:
+      spinSize = 'default';
+      break;
+  }
+
+  return (
+    <div className="container flex h-10 flex-col items-center justify-center">
+      <Spin size={spinSize as 'small' | 'default' | 'large' | undefined} />
+      <p className="f14 font-bold text-text_primary">{content}</p>
+    </div>
+  );
+}

--- a/src/components/dashboard/card/studyRoomCard.tsx
+++ b/src/components/dashboard/card/studyRoomCard.tsx
@@ -14,7 +14,7 @@ interface StudyRoomCardProps {
 export default function StudyRoomCard({ id, title, iconName, description }: StudyRoomCardProps) {
   const { confirmModal } = useModal();
   return (
-    <div className="flex w-full items-center justify-between gap-4 rounded-md p-3">
+    <div className="flex w-full items-center justify-between gap-4 rounded-md p-3 transition-transform active:scale-[0.98] active:bg-app_bg">
       <div className="flex items-center gap-4">
         <div className="rounded-md bg-icons_bg p-0.5">
           <Icons.ImageIcon name={iconName} width={36} height={36} />

--- a/src/components/studyroom/list/studyRoomFilterModal.tsx
+++ b/src/components/studyroom/list/studyRoomFilterModal.tsx
@@ -26,7 +26,7 @@ export default function StudyroomFilterModal({
     const params = new URLSearchParams(searchParams);
 
     if (date) {
-      params.set('date', date.toISOString());
+      params.set('date', new Date(date).toISOString());
     } else {
       params.delete('date');
     }
@@ -61,7 +61,7 @@ export default function StudyroomFilterModal({
       <div className="px-4">
         <h2 className="f20 mb-3 font-bold text-text_primary">날짜</h2>
         <ReservationCalendar
-          day={data.date}
+          day={new Date(data.date)}
           setSelectedDay={(date: Date) => {
             setData({ ...data, date });
           }}

--- a/src/components/studyroom/list/studyRoomReservationItem.tsx
+++ b/src/components/studyroom/list/studyRoomReservationItem.tsx
@@ -71,7 +71,7 @@ export default function StudyRoomReservationItem({
           aria-label={isExpanded ? 'Collapse details' : 'Expand details'}
         >
           <Icons.ArrowDown
-            className={`ml-1 transform fill-theme_tertiary transition-transform
+            className={`ml-1 transform fill-theme_tertiary transition-transform 
             ${isExpanded ? 'rotate-180' : 'rotate-0'}`}
             width="0.8rem"
             height="0.8rem"

--- a/src/components/studyroom/list/studyRoomSlotItem.tsx
+++ b/src/components/studyroom/list/studyRoomSlotItem.tsx
@@ -21,7 +21,7 @@ export default function StudyRoomSlotItem({ data }: StudyRoomSlotItemProps) {
   };
 
   return (
-    <div className="mb-6 flex flex-col">
+    <div className="mb-6 flex flex-col rounded-md pt-1 transition-transform active:scale-[0.98] active:bg-app_bg">
       <div className="mb-3 flex">
         <div className="mr-2 flex h-12 w-12 justify-center rounded-lg bg-slate-100 align-middle">
           {data.isCinema ? (

--- a/src/components/studyroom/modal/reservationSlider.tsx
+++ b/src/components/studyroom/modal/reservationSlider.tsx
@@ -11,12 +11,19 @@ export default function ReservationSlider({ value, onChange }: ReservationSlider
       <div className="mt-2 flex w-full px-1">
         <ConfigProvider
           theme={{
+            token: {
+              colorPrimaryBorderHover: '#626FE5',
+            },
             components: {
               Slider: {
                 railBg: '#E5E5E5',
+                railHoverBg: '#E5E5E5',
                 trackBg: '#626FE5',
+                trackBgDisabled: '#626FE5',
                 handleColor: '#626FE5',
                 handleActiveColor: '#626FE5',
+                handleColorDisabled: '#626FE5',
+                colorBorder: '#626FE5',
               },
             },
           }}

--- a/src/components/studyroom/reservationForm.tsx
+++ b/src/components/studyroom/reservationForm.tsx
@@ -9,6 +9,7 @@ import { Friend, ReservationUser, Slot, Studyroom } from '@/lib/definitions';
 import { reserveStudyroom } from '@/lib/actions/studyroom';
 import CheckUser from '@/components/studyroom/reservation/checkUser';
 import useModal from '@/hooks/useModal';
+import useLink from '@/hooks/useLink';
 import AddFriendModal from '@/components/studyroom/reservation/addFriendModal';
 
 const RANDOM_REASON = ['졸업작품', '과제', '팀 프로젝트'];
@@ -37,6 +38,7 @@ function getButtonStatus({ value, cValue }: { value: number | null; cValue: numb
 
 export default function ReservationForm({ studyRoom, friendData, date }: ReservationFormProps) {
   const { modal } = useModal();
+  const { navigatePop } = useLink();
   const today = new Date(date);
   const [friends, setFriends] = useState(friendData);
   const [startsAt, setStartsAt] = useState<number | null>(null);
@@ -96,6 +98,7 @@ export default function ReservationForm({ studyRoom, friendData, date }: Reserva
         reason,
         users: users.map((u) => u.studentId),
       });
+      navigatePop();
     } catch (e) {
       modal({
         title: '예약 실패',

--- a/src/lib/actions/studyroom.ts
+++ b/src/lib/actions/studyroom.ts
@@ -1,10 +1,8 @@
 'use server';
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
 import { StudyroomList, Studyroom, StudyroomReservationList } from '@/lib/definitions';
 import fetchExtended from '@/utils/fetchExtended';
-import { revalidateTag, unstable_noStore } from 'next/cache';
+import { revalidatePath, revalidateTag, unstable_noStore } from 'next/cache';
 import { cookies } from 'next/headers';
 
 interface StudyroomListProps {
@@ -92,6 +90,7 @@ export async function cancelReservation(id: number) {
       },
     });
     revalidateTag('reservationList');
+    revalidatePath('/dashboard/studyroom', 'page');
   } catch (error) {
     throw new Error('예약 취소에 실패했습니다.');
   }


### PR DESCRIPTION
closes #77 #78

### 작업내용
- 스터디룸 관련 영역 버튼 (카드) 누를 시 css transform 추가
- 스터디룸 페이지 빈 데이터 컴포넌트 추가 (내 예약현황, 스터디룸 목록)
- 모달에서 들어오는 데이터 타입 가드
   - undefined 통한 day에서 에러 해결 / modal 클릭 후 날짜 지정 하지 않으면 나오는 에러 해결
- 모달 슬라이더 색상 디자인 수정
- 스터디룸 예약 성공시 이전 페이지 navigatePop 추가