### PR TITLE
[#84] fix: 스터디룸 액션 로딩 상태 추가

### DIFF
--- a/src/components/common/button/button.tsx
+++ b/src/components/common/button/button.tsx
@@ -11,6 +11,7 @@ interface ButtonProps {
   className?: string;
   type?: 'button' | 'submit';
   disabled?: boolean;
+  loading?: boolean;
   onClick?: () => void;
 }
 
@@ -39,9 +40,25 @@ export default function Button({
   className = '',
   type = 'button',
   disabled = false,
+  loading = false,
   onClick = () => {},
 }: ButtonProps) {
-  return (
+  return loading ? (
+    <button
+      type={type}
+      onClick={onClick}
+      disabled
+      className={cn(
+        ButtonVariants({
+          size,
+          variant,
+        }),
+        className,
+      )}
+    >
+      처리중...
+    </button>
+  ) : (
     <button
       type={type}
       onClick={onClick}

--- a/src/components/common/button/button.tsx
+++ b/src/components/common/button/button.tsx
@@ -42,12 +42,12 @@ export default function Button({
   disabled = false,
   loading = false,
   onClick = () => {},
-}: ButtonProps) {
-  return loading ? (
+}: Readonly<ButtonProps>) {
+  return (
     <button
       type={type}
-      onClick={onClick}
-      disabled
+      onClick={!loading ? onClick : undefined}
+      disabled={disabled || loading}
       className={cn(
         ButtonVariants({
           size,
@@ -56,22 +56,7 @@ export default function Button({
         className,
       )}
     >
-      처리중...
-    </button>
-  ) : (
-    <button
-      type={type}
-      onClick={onClick}
-      disabled={disabled}
-      className={cn(
-        ButtonVariants({
-          size,
-          variant,
-        }),
-        className,
-      )}
-    >
-      {label}
+      {loading ? '처리중...' : label}
     </button>
   );
 }

--- a/src/components/dashboard/card/studyRoomCard.tsx
+++ b/src/components/dashboard/card/studyRoomCard.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import Button from '@/components/common/button/button';
 import Icons from '@/components/common/icons/icons';
 import useModal from '@/hooks/useModal';
@@ -12,6 +13,7 @@ interface StudyRoomCardProps {
   iconName: string;
 }
 export default function StudyRoomCard({ id, title, iconName, description }: StudyRoomCardProps) {
+  const [isLoading, setIsLoading] = useState(false);
   const { confirmModal } = useModal();
   return (
     <div className="flex w-full items-center justify-between gap-4 rounded-md p-3">
@@ -28,12 +30,18 @@ export default function StudyRoomCard({ id, title, iconName, description }: Stud
         size="lg"
         variant="default"
         label="취소"
+        loading={isLoading}
         onClick={() => {
           confirmModal({
             title: '예약 취소',
             content: '예약을 취소하시겠습니까?',
-            onClick: () => {
-              cancelReservation(id);
+            onClick: async () => {
+              setIsLoading(true);
+              try {
+                await cancelReservation(id);
+              } catch (e) {
+                setIsLoading(false);
+              }
             },
           });
         }}

--- a/src/components/studyroom/list/studyRoomReservationItem.tsx
+++ b/src/components/studyroom/list/studyRoomReservationItem.tsx
@@ -32,6 +32,7 @@ export default function StudyRoomReservationItem({
 
   const { trackAmplitudeEvent } = useAmplitudeContext();
   const [isExpanded, setIsExpanded] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
   const formattedDate = new Date(date).toLocaleDateString('ko-KR', {
     month: 'long',
     day: 'numeric',
@@ -53,12 +54,14 @@ export default function StudyRoomReservationItem({
       content: '예약을 취소하시겠습니까?',
       onClick: async () => {
         try {
+          setIsLoading(true);
           await onCancel(id);
           modal({
             title: '예약 취소',
             content: '예약이 취소되었습니다.',
           });
         } catch (e: unknown) {
+          setIsLoading(false);
           if (e instanceof Error) {
             modal({
               title: '예약 실패',
@@ -73,7 +76,14 @@ export default function StudyRoomReservationItem({
     <div className="mb-2 flex flex-col">
       <div className="flex justify-between">
         <span className="f16 font-bold text-text_primary">{name}</span>
-        <Button label="취소" variant="default" size="sm" type="button" onClick={handleCancel} />
+        <Button
+          label="취소"
+          variant="default"
+          size="sm"
+          type="button"
+          loading={isLoading}
+          onClick={handleCancel}
+        />
       </div>
       <div className="flex">
         <span className="f14 font-semibold text-text_secondary">

--- a/src/components/studyroom/list/studyRoomSlotItem.tsx
+++ b/src/components/studyroom/list/studyRoomSlotItem.tsx
@@ -59,8 +59,8 @@ export default function StudyRoomSlotItem({ data, date }: StudyRoomSlotItemProps
               <div
                 key={hour}
                 className={cn('h-1 w-full', {
-                  'bg-theme_primary': isClosed || isReserved,
-                  'bg-timeline_bg': !(isClosed || isReserved),
+                  'bg-theme_primary': !(isClosed || isReserved),
+                  'bg-timeline_bg': isClosed || isReserved,
                 })}
               />
             );

--- a/src/components/studyroom/reservationForm.tsx
+++ b/src/components/studyroom/reservationForm.tsx
@@ -14,7 +14,17 @@ import StackHeader from '@/components/common/stackHeader/stackHeader';
 import useViewportResize from '@/hooks/useViewportResize';
 import { isApp } from '@/utils/stackRouter';
 
-const RANDOM_REASON = ['졸업작품', '과제', '팀 프로젝트'];
+const RANDOM_REASON = [
+  '졸업작품',
+  '과제',
+  '팀 프로젝트',
+  '면접준비',
+  '취업준비',
+  '공부',
+  '휴식',
+  '기타',
+  '커피챗',
+];
 
 interface ReservationFormProps {
   studyRoom: Studyroom;

--- a/src/components/studyroom/reservationForm.tsx
+++ b/src/components/studyroom/reservationForm.tsx
@@ -47,18 +47,8 @@ export default function ReservationForm({ studyRoom, friendData, date }: Reserva
     weekday: 'long',
     timeZone: 'Asia/Seoul',
   });
-  const hour = parseInt(
-    today
-      .toLocaleDateString('ko-KR', {
-        hour: 'numeric',
-        hour12: false,
-        timeZone: 'Asia/Seoul',
-      })
-      .split(' ')[3]
-      .replace('시', ''),
-    10,
-  );
   const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
   const [friends, setFriends] = useState(friendData);
   const [startsAt, setStartsAt] = useState<number | null>(null);
   const [duration, setDuration] = useState<number | null>(null);
@@ -111,11 +101,12 @@ export default function ReservationForm({ studyRoom, friendData, date }: Reserva
       return;
     }
     try {
+      setIsLoading(true);
       await reserveStudyroom({
         studyroomId: studyRoom.id,
         date: today,
-        startsAt: startsAt!,
-        duration: duration!,
+        startsAt,
+        duration,
         reason,
         users: users.map((u) => u.studentId),
       });
@@ -129,6 +120,7 @@ export default function ReservationForm({ studyRoom, friendData, date }: Reserva
         router.back();
       }
     } catch (e: unknown) {
+      setIsLoading(false);
       if (e instanceof Error) {
         modal({
           title: '예약 실패',
@@ -176,11 +168,7 @@ export default function ReservationForm({ studyRoom, friendData, date }: Reserva
                     <div className="space-y-2">
                       <div className="flex flex-wrap gap-2">
                         {studyRoom.slots.map((slot) => {
-                          if (
-                            slot.isClosed ||
-                            hour >= slot.startsAt ||
-                            (day === '토요일' && slot.startsAt >= 16)
-                          )
+                          if (slot.isClosed || (day === '토요일' && slot.startsAt >= 16))
                             return null;
                           return (
                             <Button
@@ -316,6 +304,7 @@ export default function ReservationForm({ studyRoom, friendData, date }: Reserva
                   size="full"
                   variant="primary"
                   className="shrink-0"
+                  loading={isLoading}
                   onClick={handleReserveClick}
                 />
               </div>


### PR DESCRIPTION
closes #84 

### 작업 내용
- 대시보드 취소버튼 클릭시 로딩화면 추가
- 스터디룸 취소 모달버튼 클릭시 로딩화면 추가
- 스터디룸 폼 완료버튼 클릭시 로딩화면 추가
- 스터디룸 예약 랜덤이유 추가