### PR TITLE
[#105] fix: isLeader 분기 따라 버튼 활성화

### DIFF
--- a/src/components/studyroom/list/studyRoomReservationItem.tsx
+++ b/src/components/studyroom/list/studyRoomReservationItem.tsx
@@ -12,6 +12,7 @@ interface ReservationProps {
   date: string;
   startsAt: number;
   duration: number;
+  isLeader: boolean;
   users: {
     studentId: string;
     name: string;
@@ -25,6 +26,7 @@ export default function StudyRoomReservationItem({
   date,
   startsAt,
   duration,
+  isLeader,
   users,
   onCancel,
 }: ReservationProps) {
@@ -74,10 +76,11 @@ export default function StudyRoomReservationItem({
       <div className="flex justify-between">
         <span className="f16 font-bold text-text_primary">{name}</span>
         <Button
-          label="취소"
+          label={isLeader ? '취소' : '동반이용'}
           variant="default"
           size="sm"
           type="button"
+          disabled={!isLeader}
           loading={isLoading}
           onClick={handleCancel}
         />

--- a/src/components/studyroom/list/studyRoomReservationList.tsx
+++ b/src/components/studyroom/list/studyRoomReservationList.tsx
@@ -22,6 +22,7 @@ export default function StudyRoomReservationList({
           date={reservation.date}
           startsAt={reservation.startsAt}
           duration={reservation.duration}
+          isLeader={reservation.isLeader}
           users={reservation.users}
           onCancel={onCancel}
         />


### PR DESCRIPTION
closes #105

### 작업 내용
- isLeader 분기 따라 버튼 활성화 변경

### 작업 결과
- 버튼 disable
<img width="457" alt="스크린샷 2024-03-13 오전 1 45 37" src="https://github.com/se-gam/segam-web/assets/8311335/26ef74c6-ec13-48f6-8cf5-34807b8d74fc">
