### PR TITLE
[#141] fix: 스터디룸 리스트 정렬화

### DIFF
--- a/src/components/studyroom/studyRoomView.tsx
+++ b/src/components/studyroom/studyRoomView.tsx
@@ -17,7 +17,9 @@ export default function StudyRoomView() {
   useEffect(() => {
     const getStudyroomListData = async () => {
       const res = await getStudyroomList({ date: dateFilterData.date });
-      setStudyroomListData(res);
+      setStudyroomListData({
+        studyrooms: res.studyrooms.toSorted((a, b) => a.name.localeCompare(b.name)),
+      });
     };
     getStudyroomListData();
   }, [dateFilterData.date]);


### PR DESCRIPTION
closes #141 

- 스터디룸 슬롯 데이터 이름순 정렬
- fetch 후 state 밀어넣을때 정렬함