### PR TITLE
[#295, SEGAM-116] ESM 환경에서 __dirname 오류 해결

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,5 +1,9 @@
 import type { StorybookConfig } from '@storybook/nextjs';
 import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],


### PR DESCRIPTION
Storybook 실행시켜 보려고 했는데 `__dirname is not defined` 오류가 발생했습니다.

ES module을 사용하면 `__dirname`을 바로 사용할 수 없고 path 모듈과 fileURLToPath 메소드를 사용해야 한다고 해서 해당 부분 추가했습니다.

📚 참고자료
[https://flaviocopes.com/fix-dirname-not-defined-es-module-scope/](url)
[https://stackoverflow.com/questions/64383909/dirname-is-not-defined-error-in-node-js-14-version](url)
